### PR TITLE
Update regex pattern for username

### DIFF
--- a/src/web/lib/regex_pattern.rb
+++ b/src/web/lib/regex_pattern.rb
@@ -1,6 +1,6 @@
 module RegexPattern
 
-  Username = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i
+  Username = /^[\w\-]{1,120}$/
 
   URL = /(\A\z)|(\A(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?\z)/ix
 

--- a/src/web/lib/regex_pattern.rb
+++ b/src/web/lib/regex_pattern.rb
@@ -1,6 +1,6 @@
 module RegexPattern
 
-  Username = /\A[a-zA-Z0-9_]*\z/
+  Username = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i
 
   URL = /(\A\z)|(\A(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?\z)/ix
 


### PR DESCRIPTION
Fix regex so that the pattern is aligned with GitHub's. 
> Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen. The maximum length is 39 characters.

This may solve issue #87 .