### PR TITLE
Add Dockerfile for server and web

### DIFF
--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,0 +1,6 @@
+FROM maven AS build
+ADD . /src
+RUN mvn package -f /src
+
+FROM tomcat:8-alpine
+COPY --from=build /src/target/dist /usr/local/tomcat/webapps/

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.5
+
+WORKDIR /usr/src/app
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+CMD ["bundle", "exec", "puma", "-C", "config/puma_prod.rb"]


### PR DESCRIPTION
To improve developer efficiency, it would ideal to provide ready to use Docker images so that developers could use `docker run` to bootstrap a basic environment.

This commit adds very basic Dockerfile to server and web which could serve as a starting point to package source code into Docker images. Due to my limited experience with Java and Ruby, the final images might not work properly at the moment. Besides, we might have to improve the code base following the 12 factor best practice making the application more Docker friendly.