### PR TITLE
Update rack to 2.0.6 for addressing CVE-2018-16470+CVE-2018-16471

### DIFF
--- a/src/web/Gemfile
+++ b/src/web/Gemfile
@@ -1,4 +1,4 @@
-source 'https://anonymous:devcloud@mirrors.huaweicloud.com/repository/rubygems/'
+source 'https://rubygems.org/'
 
 gem 'haml'
 gem 'httparty'
@@ -12,6 +12,7 @@ gem 'sinatra-contrib'
 gem 'sinatra-initializers'
 gem 'sinatra-reloader'
 gem 'sinatra-sequel'
+gem 'rack', '~> 2.0.6'
 gem 'rack-contrib'
 gem 'spinying', '~> 0.9'
 gem 'sprockets'

--- a/src/web/Gemfile
+++ b/src/web/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org/'
+source 'https://anonymous:devcloud@mirrors.huaweicloud.com/repository/rubygems/'
 
 gem 'haml'
 gem 'httparty'

--- a/src/web/Gemfile.lock
+++ b/src/web/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://anonymous:devcloud@mirrors.huaweicloud.com/repository/rubygems/
   specs:
     backports (3.11.4)
     bcrypt (3.1.12-x64-mingw32)

--- a/src/web/Gemfile.lock
+++ b/src/web/Gemfile.lock
@@ -1,52 +1,48 @@
 GEM
-  remote: https://anonymous:devcloud@mirrors.huaweicloud.com/repository/rubygems/
+  remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    backports (3.11.3)
-    bcrypt (3.1.12)
+    backports (3.11.4)
     bcrypt (3.1.12-x64-mingw32)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
-    httparty (0.16.2)
+    httparty (0.16.3)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.1.0)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
     jwt (2.1.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.1)
-    minitest (5.11.3)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     mustermann (1.0.3)
     puma (3.12.0)
-    rack (2.0.5)
-    rack-contrib (2.0.1)
+    rack (2.0.6)
+    rack-contrib (2.1.0)
       rack (~> 2.0)
-    rack-protection (2.0.3)
+    rack-protection (2.0.5)
       rack
-    sequel (5.11.0)
+    sequel (5.16.0)
     sequel_secure_password (0.2.15)
       bcrypt (>= 3.1, < 4.0)
       sequel (>= 4.1.0, < 6.0)
-    sinatra (2.0.3)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.3)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.3)
-      activesupport (>= 4.0.0)
+    sinatra-contrib (2.0.5)
       backports (>= 2.8.2)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.3)
-      sinatra (= 2.0.3)
+      rack-protection (= 2.0.5)
+      sinatra (= 2.0.5)
       tilt (>= 1.3, < 3)
     sinatra-initializers (0.1.4)
     sinatra-reloader (1.0)
@@ -58,16 +54,11 @@ GEM
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sqlite3 (1.3.13)
     sqlite3 (1.3.13-x64-mingw32)
     temple (0.8.0)
-    thread_safe (0.3.6)
-    tilt (2.0.8)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
+    tilt (2.0.9)
 
 PLATFORMS
-  ruby
   x64-mingw32
 
 DEPENDENCIES
@@ -78,6 +69,7 @@ DEPENDENCIES
   mail
   multi_json
   puma
+  rack (~> 2.0.6)
   rack-contrib
   sequel
   sequel_secure_password
@@ -91,4 +83,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
Update rack to 2.0.6 for addressing CVE-2018-16470+CVE-2018-16471