### PR TITLE
chore: move config files out of war package

### DIFF
--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,9 +1,9 @@
 FROM maven:3.5-jdk-8-alpine as build
 ADD . /app
 WORKDIR /app
-COPY ./fabric ./src/main/resources/fabric
+ADD ./src/main/resources/configs.properties.docker ./src/main/resources/configs.properties
 RUN mvn install
 
 FROM tomcat:8.5-alpine
-ENV fabricAdminPrivateKeyFileName=4ad015b1-db94-ab28-b027-161c5b83376f_sk
+RUN apk add libc6-compat
 COPY --from=build /app/target/kcoin.war /usr/local/tomcat/webapps/

--- a/src/server/src/main/java/com/kcoin/fabric/FabricClient.java
+++ b/src/server/src/main/java/com/kcoin/fabric/FabricClient.java
@@ -21,6 +21,7 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
@@ -274,6 +275,13 @@ public class FabricClient {
      * @throws URISyntaxException
      */
     private String handlePlaceHolders(String content) throws Exception {
+        if (configFile.startsWith("/")) {
+            final String ccName = System.getenv("fabricChainCodeName");
+            final String ccVersion = System.getenv("fabricChainCodeVersion");
+            this.chaincodeID = ChaincodeID.newBuilder().setName(ccName).setVersion(ccVersion).build();
+            return content;
+	}
+
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
         URL yaml = classloader.getResource(configFile);
         String resourcesPath = Paths.get(yaml.toURI()).getParent().toAbsolutePath().toString();
@@ -310,8 +318,18 @@ public class FabricClient {
      * @return
      */
     private String readYamlAsString() {
-        ClassLoader classloader = Thread.currentThread().getContextClassLoader();
-        InputStream is = classloader.getResourceAsStream(configFile);
+        InputStream is;
+        if (configFile.startsWith("/")) {
+            try {
+                is = new FileInputStream(configFile);
+            } catch (Exception e) {
+                return "";
+            }
+        }
+        else {
+            ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+            is = classloader.getResourceAsStream(configFile);
+        }
         return new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
     }
 

--- a/src/server/src/main/resources/configs.properties.docker
+++ b/src/server/src/main/resources/configs.properties.docker
@@ -1,0 +1,3 @@
+# hyperLedger config which will fill the placeholders in the YAML file
+# Intend to fill the gap between VMs
+fabricSDKConfig=/etc/kcoin/kcoin-sdk-config.yaml


### PR DESCRIPTION
This PR move `kcoin-sdk-config.yaml` and fabric certificates out of the war package making it possible to deploy the server in k8s environment.

In order to keep the old behavior unchanged, we check the `configFile` setting. If it's an absolute path, we use the new behavior.

We could use another PR to change the default behavior when this PR got merged.